### PR TITLE
TOOLS-2456 Asconfig conf to yaml updates

### DIFF
--- a/json/aerospike/4.2.0.json
+++ b/json/aerospike/4.2.0.json
@@ -1792,7 +1792,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/4.3.0.json
+++ b/json/aerospike/4.3.0.json
@@ -1896,7 +1896,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/4.3.1.json
+++ b/json/aerospike/4.3.1.json
@@ -1912,7 +1912,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/4.4.0.json
+++ b/json/aerospike/4.4.0.json
@@ -1914,7 +1914,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/4.5.0.json
+++ b/json/aerospike/4.5.0.json
@@ -1948,7 +1948,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/4.5.1.json
+++ b/json/aerospike/4.5.1.json
@@ -1918,7 +1918,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/4.5.2.json
+++ b/json/aerospike/4.5.2.json
@@ -1918,7 +1918,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/4.5.3.json
+++ b/json/aerospike/4.5.3.json
@@ -1924,7 +1924,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/4.6.0.json
+++ b/json/aerospike/4.6.0.json
@@ -1930,7 +1930,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/4.7.0.json
+++ b/json/aerospike/4.7.0.json
@@ -1912,7 +1912,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/4.8.0.json
+++ b/json/aerospike/4.8.0.json
@@ -2070,7 +2070,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/4.9.0.json
+++ b/json/aerospike/4.9.0.json
@@ -2076,7 +2076,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/5.0.0.json
+++ b/json/aerospike/5.0.0.json
@@ -2031,7 +2031,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/5.1.0.json
+++ b/json/aerospike/5.1.0.json
@@ -2059,7 +2059,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/5.2.0.json
+++ b/json/aerospike/5.2.0.json
@@ -2071,7 +2071,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/5.3.0.json
+++ b/json/aerospike/5.3.0.json
@@ -2085,7 +2085,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/5.4.0.json
+++ b/json/aerospike/5.4.0.json
@@ -2091,7 +2091,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/5.5.0.json
+++ b/json/aerospike/5.5.0.json
@@ -2105,7 +2105,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/5.5.0.json
+++ b/json/aerospike/5.5.0.json
@@ -7,11 +7,6 @@
     "service": {
       "type": "object",
       "additionalProperties": false,
-      "oneOf": [{
-        "required": ["feature-key-file"]
-      }, {
-        "required": ["feature-key-files"]
-      }],
       "properties": {
         "user": {
           "type": "string",

--- a/json/aerospike/5.6.0.json
+++ b/json/aerospike/5.6.0.json
@@ -2138,7 +2138,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/5.6.0.json
+++ b/json/aerospike/5.6.0.json
@@ -7,11 +7,6 @@
     "service": {
       "type": "object",
       "additionalProperties": false,
-      "oneOf": [{
-        "required": ["feature-key-file"]
-      }, {
-        "required": ["feature-key-files"]
-      }],
       "properties": {
         "query-buf-size": {
           "type": "integer",

--- a/json/aerospike/5.7.0.json
+++ b/json/aerospike/5.7.0.json
@@ -2146,7 +2146,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/5.7.0.json
+++ b/json/aerospike/5.7.0.json
@@ -7,11 +7,6 @@
     "service": {
       "type": "object",
       "additionalProperties": false,
-      "oneOf": [{
-        "required": ["feature-key-file"]
-      }, {
-        "required": ["feature-key-files"]
-      }],
       "properties": {
         "user": {
           "type": "string",

--- a/json/aerospike/6.0.0.json
+++ b/json/aerospike/6.0.0.json
@@ -1513,7 +1513,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/6.0.0.json
+++ b/json/aerospike/6.0.0.json
@@ -7,11 +7,6 @@
     "service": {
       "type": "object",
       "additionalProperties": false,
-      "oneOf": [{
-        "required": ["feature-key-file"]
-      }, {
-        "required": ["feature-key-files"]
-      }],
       "properties": {
         "advertise-ipv6": {
           "type": "boolean",

--- a/json/aerospike/6.1.0.json
+++ b/json/aerospike/6.1.0.json
@@ -1513,7 +1513,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/6.1.0.json
+++ b/json/aerospike/6.1.0.json
@@ -7,11 +7,6 @@
     "service": {
       "type": "object",
       "additionalProperties": false,
-      "oneOf": [{
-        "required": ["feature-key-file"]
-      }, {
-        "required": ["feature-key-files"]
-      }],
       "properties": {
         "advertise-ipv6": {
           "type": "boolean",

--- a/json/aerospike/6.2.0.json
+++ b/json/aerospike/6.2.0.json
@@ -1513,7 +1513,7 @@
             "type": "integer",
             "default": 256,
             "minimum": 16,
-            "maximum": 4096,
+            "maximum": 268453456,
             "description": "",
             "dynamic": false
           },

--- a/json/aerospike/6.2.0.json
+++ b/json/aerospike/6.2.0.json
@@ -7,11 +7,6 @@
     "service": {
       "type": "object",
       "additionalProperties": false,
-      "oneOf": [{
-        "required": ["feature-key-file"]
-      }, {
-        "required": ["feature-key-files"]
-      }],
       "properties": {
         "advertise-ipv6": {
           "type": "boolean",

--- a/json/aerospike/6.3.0.json
+++ b/json/aerospike/6.3.0.json
@@ -7,11 +7,6 @@
       "service": {
         "type": "object",
         "additionalProperties": false,
-        "oneOf": [{
-          "required": ["feature-key-file"]
-        }, {
-          "required": ["feature-key-files"]
-        }],
         "properties": {
           "advertise-ipv6": {
             "type": "boolean",
@@ -1563,7 +1558,7 @@
               "type": "integer",
               "default": 256,
               "minimum": 16,
-              "maximum": 4096,
+              "maximum": 268453456,
               "description": "",
               "dynamic": false
             },


### PR DESCRIPTION
This makes fixes for issues found while adding asconfig to yaml support to [asconfig](https://github.com/aerospike/asconfig/pull/9).

Bumps max tree sprig count up to new value.
Makes feature-key-file(s) optional to support CE servers.