### PR TITLE
fix: TOOLS-3080 update min value for max-record-size in Aerospike 8.0.0 schema

### DIFF
--- a/json/aerospike/8.0.0.json
+++ b/json/aerospike/8.0.0.json
@@ -1784,7 +1784,7 @@
           "max-record-size": {
             "type": "integer",
             "default": 1048576,
-            "minimum": 0,
+            "minimum": 64,
             "maximum": 8388608,
             "description": "",
             "dynamic": true,


### PR DESCRIPTION
Changed the minimum allowed value for the 'max-record-size' property from 0 to 64 in the Aerospike 8.0.0 JSON schema to reflect updated configuration constraints.