### PR TITLE
fix: Add 'service' to required fields in Aerospike schemas

### DIFF
--- a/json/aerospike/7.0.0.json
+++ b/json/aerospike/7.0.0.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-06/schema",
   "additionalProperties": false,
   "type": "object",
-  "required": ["network", "namespaces"],
+  "required": ["service", "network", "namespaces"],
   "properties": {
     "service": {
       "type": "object",

--- a/json/aerospike/7.1.0.json
+++ b/json/aerospike/7.1.0.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-06/schema",
   "additionalProperties": false,
   "type": "object",
-  "required": ["network", "namespaces"],
+  "required": ["service", "network", "namespaces"],
   "properties": {
     "service": {
       "type": "object",

--- a/json/aerospike/7.2.0.json
+++ b/json/aerospike/7.2.0.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-06/schema",
   "additionalProperties": false,
   "type": "object",
-  "required": ["network", "namespaces"],
+  "required": ["service", "network", "namespaces"],
   "properties": {
     "service": {
       "type": "object",

--- a/json/aerospike/8.0.0.json
+++ b/json/aerospike/8.0.0.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-06/schema",
   "additionalProperties": false,
   "type": "object",
-  "required": ["network", "namespaces"],
+  "required": ["service", "network", "namespaces"],
   "properties": {
     "service": {
       "type": "object",


### PR DESCRIPTION
Updated Aerospike JSON schemas for versions 7.0.0, 7.1.0, 7.2.0, and 8.0.0 to include 'service' in the list of required properties. This ensures that the 'service' object is always present in configuration files validated against these schemas.