### PR TITLE
feat: TOOLS-3166 add masking configuration to Aerospike 8.1.1 schema

### DIFF
--- a/json/aerospike/8.1.1.json
+++ b/json/aerospike/8.1.1.json
@@ -914,6 +914,13 @@
             "enterpriseOnly": false,
             "default": "CRITICAL"
           },
+          "masking": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
           "any": {
             "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
             "description": "",


### PR DESCRIPTION
Added a new 'masking' property to the Aerospike 8.1.1 JSON schema in logging context, including an enum for log levels and default settings.