### PR TITLE
feat: TOOLS-3291 Add Aerospike 8.1.2 JSON schema

### DIFF
--- a/json/aerospike/8.1.2.json
+++ b/json/aerospike/8.1.2.json
@@ -1,0 +1,3733 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema",
+  "additionalProperties": false,
+  "type": "object",
+  "required": ["service", "network", "namespaces"],
+  "properties": {
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "enterpriseOnly": false,
+      "required": ["cluster-name"],
+      "properties": {
+        "advertise-ipv6": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "auto-pin": {
+          "type": "string",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false,
+          "default": "none",
+          "enum": ["none", "cpu", "numa", "adq"]
+        },
+        "batch-index-threads": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 1,
+          "maximum": 256,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "batch-max-buffers-per-queue": {
+          "type": "integer",
+          "default": 255,
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "batch-max-requests": {
+          "type": "integer",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "batch-max-unused-buffers": {
+          "type": "integer",
+          "default": 256,
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "cgroup-mem-tracking": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "cluster-name": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "debug-allocations": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "disable-udf-execution": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "enable-benchmarks-fabric": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "enable-health-check": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "enable-hist-info": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "enforce-best-practices": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "feature-key-file": {
+          "type": "string",
+          "default": "/etc/aerospike/features.conf",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": true
+        },
+        "feature-key-files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": true,
+          "default": ["/etc/aerospike/features.conf"]
+        },
+        "group": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "indent-allocations": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "info-max-ms": {
+          "type": "integer",
+          "default": 10000,
+          "minimum": 500,
+          "maximum": 10000,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "info-threads": {
+          "type": "integer",
+          "default": 16,
+          "minimum": 0,
+          "maximum": 2147483647,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "keep-caps-ssd-health": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "log-local-time": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "log-millis": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "microsecond-histograms": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "migrate-fill-delay": {
+          "type": "integer",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": true
+        },
+        "migrate-max-num-incoming": {
+          "type": "integer",
+          "default": 4,
+          "minimum": 0,
+          "maximum": 256,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "migrate-threads": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 100,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "min-cluster-size": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 256,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "node-id": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "node-id-interface": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "os-group-perms": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "pidfile": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "poison-allocations": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "proto-fd-idle-ms": {
+          "type": "integer",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 2147483647,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "proto-fd-max": {
+          "type": "integer",
+          "default": 15000,
+          "minimum": 0,
+          "maximum": 2147483647,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "quarantine-allocations": {
+          "type": "integer",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 100000000,
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "query-max-done": {
+          "type": "integer",
+          "default": 100,
+          "minimum": 0,
+          "maximum": 10000,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "query-threads-limit": {
+          "type": "integer",
+          "default": 128,
+          "minimum": 1,
+          "maximum": 1024,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "run-as-daemon": {
+          "type": "boolean",
+          "default": true,
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "secrets-address-port": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": true
+        },
+        "secrets-tls-context": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": true
+        },
+        "secrets-uds-path": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": true
+        },
+        "service-threads": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 1,
+          "maximum": 4096,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "sindex-builder-threads": {
+          "type": "integer",
+          "default": 4,
+          "minimum": 1,
+          "maximum": 32,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "sindex-gc-period": {
+          "type": "integer",
+          "default": 10,
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "stay-quiesced": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": true
+        },
+        "ticker-interval": {
+          "type": "integer",
+          "default": 10,
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "tls-refresh-period": {
+          "type": "integer",
+          "default": 60,
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": true
+        },
+        "transaction-max-ms": {
+          "type": "integer",
+          "default": 1000,
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "transaction-retry-ms": {
+          "type": "integer",
+          "default": 1002,
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": false
+        },
+        "user": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "vault-ca": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": true
+        },
+        "vault-namespace": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": true
+        },
+        "vault-path": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": true
+        },
+        "vault-token-file": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": true
+        },
+        "vault-url": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": true
+        },
+        "work-directory": {
+          "type": "string",
+          "default": "/opt/aerospike",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        }
+      }
+    },
+    "logging": {
+      "type": "array",
+      "enterpriseOnly": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": " ",
+            "description": "",
+            "dynamic": false,
+            "enterpriseOnly": false
+          },
+          "misc": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "alloc": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "arenax": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "hardware": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "msg": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "os": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "secrets": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "socket": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "tls": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "vault": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "vmapx": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "xmem": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "aggr": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "appeal": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "as": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "audit": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "batch": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "batch-sub": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "bin": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "config": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "clustering": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "deprecation": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "drv-mem": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "drv_pmem": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "drv_ssd": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "exchange": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "exp": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "fabric": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "flat": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "geo": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "hb": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "health": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "hlc": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "index": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "info": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "info-command": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "key-busy": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "migrate": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "mrt-audit": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "mrt-monitor": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "namespace": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "nsup": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "particle": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "partition": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "proto": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "proxy": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "proxy-divert": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "query": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "record": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "roster": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "rw": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "rw-client": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "security": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "service": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "service-list": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "sindex": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "skew": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "smd": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "storage": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "truncate": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "tsvc": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "udf": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "xdr": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "xdr-client": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "masking": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "any": {
+            "enum": ["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"],
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "CRITICAL"
+          },
+          "facility": {
+            "enum": ["auth", "authpriv", "cron", "daemon", "ftp", "kern", "lpr", "mail", "news", "syslog", "user", "uucp", "local0", "local1", "local2", "local3", "local4", "local5", "local6", "local7"],
+            "description": "",
+            "dynamic": false,
+            "default": "local0"
+          },
+          "path": {
+            "type": "string",
+            "default": "/dev/log",
+            "description": "",
+            "dynamic": false,
+            "enterpriseOnly": false
+          },
+          "tag": {
+            "type": "string",
+            "default": "asd",
+            "description": "",
+            "dynamic": false,
+            "enterpriseOnly": false
+          }
+        }
+      }
+    },
+    "network": {
+      "type": "object",
+      "additionalProperties": false,
+      "enterpriseOnly": false,
+      "required": ["service", "heartbeat", "fabric"],
+      "properties": {
+        "service": {
+          "type": "object",
+          "additionalProperties": false,
+          "enterpriseOnly": false,
+          "anyOf": [{
+            "required": ["port"]
+          }, {
+            "required": ["tls-name", "tls-port"]
+          }],
+          "properties": {
+            "access-addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false,
+              "default": []
+            },
+            "access-port": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 1024,
+              "maximum": 65535,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false,
+              "default": []
+            },
+            "alternate-access-addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false,
+              "default": []
+            },
+            "alternate-access-port": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 1024,
+              "maximum": 65535,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "disable-localhost": {
+              "type": "boolean",
+              "default": false,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "port": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 1024,
+              "maximum": 65535,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "tls-access-addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true,
+              "default": []
+            },
+            "tls-access-port": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 1024,
+              "maximum": 65535,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "tls-addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true,
+              "default": []
+            },
+            "tls-alternate-access-addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true,
+              "default": []
+            },
+            "tls-alternate-access-port": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 1024,
+              "maximum": 65535,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "tls-authenticate-client": {
+              "enterpriseOnly": true,
+              "oneOf": [{
+                "type": "string",
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": true,
+                "default": "any",
+                "enum": ["any", "false"]
+              }, {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "hostname",
+                  "not": {
+                    "enum": ["any", "false"]
+                  }
+                }
+              }]
+            },
+            "tls-name": {
+              "type": "string",
+              "default": "",
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "tls-port": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 1024,
+              "maximum": 65535,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            }
+          }
+        },
+        "admin": {
+          "type": "object",
+          "additionalProperties": false,
+          "enterpriseOnly": false,
+          "anyOf": [{
+            "required": ["port"]
+          }, {
+            "required": ["tls-name", "tls-port"]
+          }],
+          "properties": {
+            "addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false,
+              "default": []
+            },
+            "disable-localhost": {
+              "type": "boolean",
+              "default": false,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "port": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 1024,
+              "maximum": 65535,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "tls-addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true,
+              "default": []
+            },
+            "tls-authenticate-client": {
+              "enterpriseOnly": true,
+              "oneOf": [{
+                "type": "string",
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": true,
+                "default": "any",
+                "enum": ["any", "false"]
+              }, {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "hostname",
+                  "not": {
+                    "enum": ["any", "false"]
+                  }
+                }
+              }]
+            },
+            "tls-name": {
+              "type": "string",
+              "default": "",
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "tls-port": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 1024,
+              "maximum": 65535,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            }
+          }
+        },
+        "heartbeat": {
+          "type": "object",
+          "additionalProperties": false,
+          "enterpriseOnly": false,
+          "anyOf": [{
+            "required": ["mode", "port"]
+          }, {
+            "required": ["mode", "tls-name", "tls-port"]
+          }],
+          "properties": {
+            "addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false,
+              "default": []
+            },
+            "connect-timeout-ms": {
+              "type": "integer",
+              "default": 500,
+              "minimum": 50,
+              "maximum": 4294967295,
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": false
+            },
+            "interval": {
+              "type": "integer",
+              "default": 150,
+              "minimum": 50,
+              "maximum": 600000,
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": false
+            },
+            "mesh-seed-address-ports": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false,
+              "default": []
+            },
+            "mode": {
+              "type": "string",
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false,
+              "default": "",
+              "enum": ["mesh", "multicast"]
+            },
+            "mtu": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0,
+              "maximum": 4294967295,
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": false
+            },
+            "multicast-groups": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false,
+              "default": []
+            },
+            "multicast-ttl": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0,
+              "maximum": 255,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "port": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 1024,
+              "maximum": 65535,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "protocol": {
+              "type": "string",
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": false,
+              "default": "v3",
+              "enum": ["none", "v3"]
+            },
+            "timeout": {
+              "type": "integer",
+              "default": 10,
+              "minimum": 3,
+              "maximum": 4294967295,
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": false
+            },
+            "tls-addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true,
+              "default": []
+            },
+            "tls-mesh-seed-address-ports": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true,
+              "default": []
+            },
+            "tls-name": {
+              "type": "string",
+              "default": "",
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "tls-port": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 1024,
+              "maximum": 65535,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            }
+          }
+        },
+        "fabric": {
+          "type": "object",
+          "additionalProperties": false,
+          "enterpriseOnly": false,
+          "anyOf": [{
+            "required": ["port"]
+          }, {
+            "required": ["tls-name", "tls-port"]
+          }],
+          "properties": {
+            "addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false,
+              "default": []
+            },
+            "channel-bulk-fds": {
+              "type": "integer",
+              "default": 2,
+              "minimum": 1,
+              "maximum": 128,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "channel-bulk-recv-threads": {
+              "type": "integer",
+              "default": 4,
+              "minimum": 1,
+              "maximum": 128,
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": false
+            },
+            "channel-ctrl-fds": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "maximum": 128,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "channel-ctrl-recv-threads": {
+              "type": "integer",
+              "default": 4,
+              "minimum": 1,
+              "maximum": 128,
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": false
+            },
+            "channel-meta-fds": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "maximum": 128,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "channel-meta-recv-threads": {
+              "type": "integer",
+              "default": 4,
+              "minimum": 1,
+              "maximum": 128,
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": false
+            },
+            "channel-rw-fds": {
+              "type": "integer",
+              "default": 8,
+              "minimum": 1,
+              "maximum": 128,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "channel-rw-recv-pools": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "maximum": 16,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "channel-rw-recv-threads": {
+              "type": "integer",
+              "default": 16,
+              "minimum": 1,
+              "maximum": 128,
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": false
+            },
+            "keepalive-enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "keepalive-intvl": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "maximum": 2147483647,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "keepalive-probes": {
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 2147483647,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "keepalive-time": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "maximum": 2147483647,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "latency-max-ms": {
+              "type": "integer",
+              "default": 5,
+              "minimum": 0,
+              "maximum": 1000,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "port": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 1024,
+              "maximum": 65535,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "recv-rearm-threshold": {
+              "type": "integer",
+              "default": 1024,
+              "minimum": 0,
+              "maximum": 1048576,
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": false
+            },
+            "send-threads": {
+              "type": "integer",
+              "default": 8,
+              "minimum": 1,
+              "maximum": 128,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": false
+            },
+            "tls-addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true,
+              "default": []
+            },
+            "tls-name": {
+              "type": "string",
+              "default": "",
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "tls-port": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 1024,
+              "maximum": 65535,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "enterpriseOnly": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "default": " ",
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": true
+              },
+              "ca-file": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": true
+              },
+              "ca-path": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": true
+              },
+              "cert-blacklist": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": true
+              },
+              "cert-file": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": true
+              },
+              "cipher-suite": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": true
+              },
+              "key-file": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": true
+              },
+              "key-file-password": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": true
+              },
+              "pki-user-append-ou": {
+                "type": "boolean",
+                "default": false,
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": true
+              },
+              "protocols": {
+                "type": "string",
+                "default": "TLSv1.2",
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "namespaces": {
+      "type": "array",
+      "minItems": 1,
+      "enterpriseOnly": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": " ",
+            "description": "",
+            "dynamic": false,
+            "enterpriseOnly": false
+          },
+          "active-rack": {
+            "type": "integer",
+            "default": 0,
+            "minimum": 0,
+            "maximum": 1000000,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "allow-ttl-without-nsup": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "apply-ttl-reductions": {
+            "type": "boolean",
+            "default": true,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "auto-revive": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": false,
+            "enterpriseOnly": true
+          },
+          "background-query-max-rps": {
+            "type": "integer",
+            "default": 10000,
+            "minimum": 1,
+            "maximum": 1000000,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "conflict-resolution-policy": {
+            "type": "string",
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "generation",
+            "enum": ["generation", "last-update-time"]
+          },
+          "conflict-resolve-writes": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "default-read-touch-ttl-pct": {
+            "type": "integer",
+            "default": 0,
+            "minimum": 0,
+            "maximum": 100,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "default-ttl": {
+            "type": "integer",
+            "default": 0,
+            "minimum": 0,
+            "maximum": 315360000,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "disable-cold-start-eviction": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": false,
+            "enterpriseOnly": false
+          },
+          "disable-mrt-writes": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "disable-write-dup-res": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "disallow-expunge": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "disallow-null-setname": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "enable-benchmarks-batch-sub": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "enable-benchmarks-ops-sub": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "enable-benchmarks-read": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "enable-benchmarks-udf": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "enable-benchmarks-udf-sub": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "enable-benchmarks-write": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "enable-hist-proxy": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "evict-hist-buckets": {
+            "type": "integer",
+            "default": 10000,
+            "minimum": 100,
+            "maximum": 10000000,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "evict-indexes-memory-pct": {
+            "type": "integer",
+            "default": 0,
+            "minimum": 0,
+            "maximum": 100,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "evict-tenths-pct": {
+            "type": "integer",
+            "default": 5,
+            "minimum": 0,
+            "maximum": 4294967295,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "ignore-migrate-fill-delay": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "index-stage-size": {
+            "type": "integer",
+            "default": 1073741824,
+            "minimum": 134217728,
+            "maximum": 17179869184,
+            "description": "",
+            "dynamic": false,
+            "enterpriseOnly": false
+          },
+          "indexes-memory-budget": {
+            "type": "integer",
+            "default": 0,
+            "minimum": 0,
+            "maximum": 18446744073709551615,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "inline-short-queries": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "max-record-size": {
+            "type": "integer",
+            "default": 1048576,
+            "minimum": 64,
+            "maximum": 8388608,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "migrate-order": {
+            "type": "integer",
+            "default": 5,
+            "minimum": 1,
+            "maximum": 10,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "migrate-retransmit-ms": {
+            "type": "integer",
+            "default": 5000,
+            "minimum": 0,
+            "maximum": 4294967295,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "migrate-skip-unreadable": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "migrate-sleep": {
+            "type": "integer",
+            "default": 1,
+            "minimum": 0,
+            "maximum": 4294967295,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "mrt-duration": {
+            "type": "integer",
+            "default": 10,
+            "minimum": 1,
+            "maximum": 120,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "nsup-hist-period": {
+            "type": "integer",
+            "default": 3600,
+            "minimum": 0,
+            "maximum": 4294967295,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "nsup-period": {
+            "type": "integer",
+            "default": 0,
+            "minimum": 0,
+            "maximum": 4294967295,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "nsup-threads": {
+            "type": "integer",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 128,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "partition-tree-sprigs": {
+            "type": "integer",
+            "default": 256,
+            "minimum": 256,
+            "maximum": 268435456,
+            "description": "",
+            "dynamic": false,
+            "enterpriseOnly": false
+          },
+          "prefer-uniform-balance": {
+            "type": "boolean",
+            "default": true,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "rack-id": {
+            "type": "integer",
+            "default": 0,
+            "minimum": 0,
+            "maximum": 1000000,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "read-consistency-level-override": {
+            "type": "string",
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "off",
+            "enum": ["all", "off", "one"]
+          },
+          "reject-non-xdr-writes": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "reject-xdr-writes": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "replication-factor": {
+            "type": "integer",
+            "default": 2,
+            "minimum": 1,
+            "maximum": 256,
+            "description": "",
+            "dynamic": false,
+            "enterpriseOnly": false
+          },
+          "sindex-stage-size": {
+            "type": "integer",
+            "default": 1073741824,
+            "minimum": 134217728,
+            "maximum": 4294967296,
+            "description": "",
+            "dynamic": false,
+            "enterpriseOnly": false
+          },
+          "single-query-threads": {
+            "type": "integer",
+            "default": 4,
+            "minimum": 1,
+            "maximum": 128,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "stop-writes-sys-memory-pct": {
+            "type": "integer",
+            "default": 90,
+            "minimum": 0,
+            "maximum": 100,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "strong-consistency": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": false,
+            "enterpriseOnly": true
+          },
+          "strong-consistency-allow-expunge": {
+            "type": "boolean",
+            "default": false,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "tomb-raider-eligible-age": {
+            "type": "integer",
+            "default": 86400,
+            "minimum": 0,
+            "maximum": 4294967295,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "tomb-raider-period": {
+            "type": "integer",
+            "default": 86400,
+            "minimum": 0,
+            "maximum": 4294967295,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "tomb-raider-unmark-threads": {
+            "type": "integer",
+            "default": 0,
+            "minimum": 0,
+            "maximum": 128,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "transaction-pending-limit": {
+            "type": "integer",
+            "default": 20,
+            "minimum": 0,
+            "maximum": 4294967295,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "truncate-threads": {
+            "type": "integer",
+            "default": 4,
+            "minimum": 1,
+            "maximum": 128,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false
+          },
+          "write-commit-level-override": {
+            "type": "string",
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": false,
+            "default": "off",
+            "enum": ["all", "master", "off"]
+          },
+          "xdr-bin-tombstone-ttl": {
+            "type": "integer",
+            "default": 86400,
+            "minimum": 0,
+            "maximum": 315360000,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "xdr-tomb-raider-period": {
+            "type": "integer",
+            "default": 120,
+            "minimum": 0,
+            "maximum": 4294967295,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "xdr-tomb-raider-threads": {
+            "type": "integer",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 128,
+            "description": "",
+            "dynamic": true,
+            "enterpriseOnly": true
+          },
+          "geo2dsphere-within": {
+            "type": "object",
+            "additionalProperties": false,
+            "enterpriseOnly": false,
+            "properties": {
+              "strict": {
+                "type": "boolean",
+                "default": true,
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": false
+              },
+              "min-level": {
+                "type": "integer",
+                "default": 1,
+                "minimum": 0,
+                "maximum": 30,
+                "description": "",
+                "dynamic": true,
+                "enterpriseOnly": false
+              },
+              "max-level": {
+                "type": "integer",
+                "default": 20,
+                "minimum": 0,
+                "maximum": 30,
+                "description": "",
+                "dynamic": true,
+                "enterpriseOnly": false
+              },
+              "max-cells": {
+                "type": "integer",
+                "default": 12,
+                "minimum": 1,
+                "maximum": 256,
+                "description": "",
+                "dynamic": true,
+                "enterpriseOnly": false
+              },
+              "level-mod": {
+                "type": "integer",
+                "default": 1,
+                "minimum": 1,
+                "maximum": 3,
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": false
+              },
+              "earth-radius-meters": {
+                "type": "integer",
+                "default": 6371000,
+                "minimum": 0,
+                "maximum": 4294967295,
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": false
+              }
+            }
+          },
+          "index-type": {
+            "enterpriseOnly": true,
+            "oneOf": [{
+              "type": "object",
+              "additionalProperties": false,
+              "enterpriseOnly": true,
+              "required": ["type"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": "shmem",
+                  "enum": ["shmem"]
+                }
+              }
+            }, {
+              "type": "object",
+              "additionalProperties": false,
+              "enterpriseOnly": true,
+              "required": ["type", "mounts", "mounts-budget"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": "pmem",
+                  "enum": ["pmem"]
+                },
+                "evict-mounts-pct": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "mounts": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": []
+                },
+                "mounts-budget": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 1073741824,
+                  "maximum": 18446744073709551615,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                }
+              }
+            }, {
+              "type": "object",
+              "additionalProperties": false,
+              "enterpriseOnly": true,
+              "required": ["type", "mounts", "mounts-budget"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": "flash",
+                  "enum": ["flash"]
+                },
+                "evict-mounts-pct": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "mounts": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": []
+                },
+                "mounts-budget": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 4294967296,
+                  "maximum": 18446744073709551615,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                }
+              }
+            }]
+          },
+          "sets": {
+            "type": "array",
+            "enterpriseOnly": false,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "default": " ",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false
+                },
+                "default-read-touch-ttl-pct": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": -1,
+                  "maximum": 100,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "default-ttl": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 315360000,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "disable-eviction": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "enable-index": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "stop-writes-count": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 18446744073709551615,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "stop-writes-size": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 18446744073709551615,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                }
+              }
+            }
+          },
+          "sindex-type": {
+            "enterpriseOnly": true,
+            "oneOf": [{
+              "type": "object",
+              "additionalProperties": false,
+              "enterpriseOnly": true,
+              "required": ["type"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": "shmem",
+                  "enum": ["shmem"]
+                }
+              }
+            }, {
+              "type": "object",
+              "additionalProperties": false,
+              "enterpriseOnly": true,
+              "required": ["type", "mounts", "mounts-budget"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": "pmem",
+                  "enum": ["pmem"]
+                },
+                "evict-mounts-pct": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "mounts": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": []
+                },
+                "mounts-budget": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 1073741824,
+                  "maximum": 18446744073709551615,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                }
+              }
+            }, {
+              "type": "object",
+              "additionalProperties": false,
+              "enterpriseOnly": true,
+              "required": ["type", "mounts", "mounts-budget"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": "flash",
+                  "enum": ["flash"]
+                },
+                "evict-mounts-pct": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "mounts": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": []
+                },
+                "mounts-budget": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 1073741824,
+                  "maximum": 18446744073709551615,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                }
+              }
+            }]
+          },
+          "storage-engine": {
+            "enterpriseOnly": false,
+            "oneOf": [{
+              "type": "object",
+              "additionalProperties": false,
+              "enterpriseOnly": false,
+              "oneOf": [{
+                "required": ["type", "devices"]
+              }, {
+                "required": ["type", "files"]
+              }, {
+                "required": ["type", "data-size"]
+              }],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false,
+                  "default": "memory",
+                  "enum": ["memory"]
+                },
+                "commit-to-device": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true
+                },
+                "compression": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true,
+                  "default": "none",
+                  "enum": ["none", "lz4", "snappy", "zstd"]
+                },
+                "compression-acceleration": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 1,
+                  "maximum": 65537,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "compression-level": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 1,
+                  "maximum": 9,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "data-size": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 536870912,
+                  "maximum": 281474976710656,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false
+                },
+                "defrag-lwm-pct": {
+                  "type": "integer",
+                  "default": 50,
+                  "minimum": 1,
+                  "maximum": 99,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "defrag-queue-min": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 4294967295,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "defrag-sleep": {
+                  "type": "integer",
+                  "default": 1000,
+                  "minimum": 0,
+                  "maximum": 4294967295,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "defrag-startup-minimum": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 99,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false
+                },
+                "devices": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false,
+                  "default": []
+                },
+                "direct-files": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false
+                },
+                "disable-odsync": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false
+                },
+                "enable-benchmarks-storage": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "encryption": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": "aes-128",
+                  "enum": ["aes-128", "aes-256"]
+                },
+                "encryption-key-file": {
+                  "type": "string",
+                  "default": "",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true
+                },
+                "encryption-old-key-file": {
+                  "type": "string",
+                  "default": "",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true
+                },
+                "evict-used-pct": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "files": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false,
+                  "default": []
+                },
+                "filesize": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 134217728,
+                  "maximum": 2199023255552,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false
+                },
+                "flush-max-ms": {
+                  "type": "integer",
+                  "default": 1000,
+                  "minimum": 0,
+                  "maximum": 1000,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "flush-size": {
+                  "type": "integer",
+                  "default": 1048576,
+                  "minimum": 4096,
+                  "maximum": 8388608,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "max-write-cache": {
+                  "type": "integer",
+                  "default": 67108864,
+                  "minimum": 0,
+                  "maximum": 18446744073709551615,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "stop-writes-avail-pct": {
+                  "type": "integer",
+                  "default": 5,
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "stop-writes-used-pct": {
+                  "type": "integer",
+                  "default": 70,
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "tomb-raider-sleep": {
+                  "type": "integer",
+                  "default": 1000,
+                  "minimum": 0,
+                  "maximum": 4294967295,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                }
+              }
+            }, {
+              "type": "object",
+              "additionalProperties": false,
+              "enterpriseOnly": false,
+              "oneOf": [{
+                "required": ["type", "devices"]
+              }, {
+                "required": ["type", "files"]
+              }],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false,
+                  "default": "device",
+                  "enum": ["device"]
+                },
+                "cache-replica-writes": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "cold-start-empty": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false
+                },
+                "commit-to-device": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true
+                },
+                "compression": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true,
+                  "default": "none",
+                  "enum": ["none", "lz4", "snappy", "zstd"]
+                },
+                "compression-acceleration": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 1,
+                  "maximum": 65537,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "compression-level": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 1,
+                  "maximum": 9,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "defrag-lwm-pct": {
+                  "type": "integer",
+                  "default": 50,
+                  "minimum": 1,
+                  "maximum": 99,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "defrag-queue-min": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 4294967295,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "defrag-sleep": {
+                  "type": "integer",
+                  "default": 1000,
+                  "minimum": 0,
+                  "maximum": 4294967295,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "defrag-startup-minimum": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 99,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false
+                },
+                "devices": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false,
+                  "default": []
+                },
+                "direct-files": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false
+                },
+                "disable-odsync": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false
+                },
+                "enable-benchmarks-storage": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "encryption": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": "aes-128",
+                  "enum": ["aes-128", "aes-256"]
+                },
+                "encryption-key-file": {
+                  "type": "string",
+                  "default": "",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true
+                },
+                "encryption-old-key-file": {
+                  "type": "string",
+                  "default": "",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true
+                },
+                "evict-used-pct": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "files": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false,
+                  "default": []
+                },
+                "filesize": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 134217728,
+                  "maximum": 2199023255552,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false
+                },
+                "flush-max-ms": {
+                  "type": "integer",
+                  "default": 1000,
+                  "minimum": 0,
+                  "maximum": 1000,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "flush-size": {
+                  "type": "integer",
+                  "default": 1048576,
+                  "minimum": 4096,
+                  "maximum": 8388608,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "max-write-cache": {
+                  "type": "integer",
+                  "default": 67108864,
+                  "minimum": 0,
+                  "maximum": 18446744073709551615,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "post-write-cache": {
+                  "type": "integer",
+                  "default": 268435456,
+                  "minimum": 0,
+                  "maximum": 18446744073709551615,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "read-page-cache": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "serialize-tomb-raider": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true
+                },
+                "sindex-startup-device-scan": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": false
+                },
+                "stop-writes-avail-pct": {
+                  "type": "integer",
+                  "default": 5,
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "stop-writes-used-pct": {
+                  "type": "integer",
+                  "default": 70,
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": false
+                },
+                "tomb-raider-sleep": {
+                  "type": "integer",
+                  "default": 1000,
+                  "minimum": 0,
+                  "maximum": 4294967295,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                }
+              }
+            }, {
+              "type": "object",
+              "additionalProperties": false,
+              "enterpriseOnly": true,
+              "required": ["type", "files"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": "pmem",
+                  "enum": ["pmem"]
+                },
+                "commit-to-device": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true
+                },
+                "compression": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true,
+                  "default": "none",
+                  "enum": ["none", "lz4", "snappy", "zstd"]
+                },
+                "compression-acceleration": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 1,
+                  "maximum": 65537,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "compression-level": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 1,
+                  "maximum": 9,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "defrag-lwm-pct": {
+                  "type": "integer",
+                  "default": 50,
+                  "minimum": 1,
+                  "maximum": 99,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "defrag-queue-min": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 4294967295,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "defrag-sleep": {
+                  "type": "integer",
+                  "default": 1000,
+                  "minimum": 0,
+                  "maximum": 4294967295,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "defrag-startup-minimum": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 99,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true
+                },
+                "direct-files": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true
+                },
+                "disable-odsync": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true
+                },
+                "enable-benchmarks-storage": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "encryption": {
+                  "type": "string",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": "aes-128",
+                  "enum": ["aes-128", "aes-256"]
+                },
+                "encryption-key-file": {
+                  "type": "string",
+                  "default": "",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true
+                },
+                "encryption-old-key-file": {
+                  "type": "string",
+                  "default": "",
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true
+                },
+                "evict-used-pct": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "files": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true,
+                  "default": []
+                },
+                "filesize": {
+                  "type": "integer",
+                  "default": 0,
+                  "minimum": 134217728,
+                  "maximum": 2199023255552,
+                  "description": "",
+                  "dynamic": false,
+                  "enterpriseOnly": true
+                },
+                "flush-max-ms": {
+                  "type": "integer",
+                  "default": 1000,
+                  "minimum": 0,
+                  "maximum": 1000,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "max-write-cache": {
+                  "type": "integer",
+                  "default": 67108864,
+                  "minimum": 0,
+                  "maximum": 18446744073709551615,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "stop-writes-avail-pct": {
+                  "type": "integer",
+                  "default": 5,
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "stop-writes-used-pct": {
+                  "type": "integer",
+                  "default": 70,
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                },
+                "tomb-raider-sleep": {
+                  "type": "integer",
+                  "default": 1000,
+                  "minimum": 0,
+                  "maximum": 4294967295,
+                  "description": "",
+                  "dynamic": true,
+                  "enterpriseOnly": true
+                }
+              }
+            }]
+          }
+        }
+      }
+    },
+    "mod-lua": {
+      "type": "object",
+      "additionalProperties": false,
+      "enterpriseOnly": false,
+      "properties": {
+        "cache-enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        },
+        "user-path": {
+          "type": "string",
+          "default": "/opt/aerospike/usr/udf/lua",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": false
+        }
+      }
+    },
+    "security": {
+      "type": "object",
+      "additionalProperties": false,
+      "enterpriseOnly": true,
+      "properties": {
+        "default-password-file": {
+          "type": "string",
+          "default": "",
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": true
+        },
+        "enable-quotas": {
+          "type": "boolean",
+          "default": false,
+          "description": "",
+          "dynamic": false,
+          "enterpriseOnly": true
+        },
+        "privilege-refresh-period": {
+          "type": "integer",
+          "default": 300,
+          "minimum": 10,
+          "maximum": 86400,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": true
+        },
+        "session-ttl": {
+          "type": "integer",
+          "default": 86400,
+          "minimum": 120,
+          "maximum": 864000,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": true
+        },
+        "tps-weight": {
+          "type": "integer",
+          "default": 2,
+          "minimum": 2,
+          "maximum": 20,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": true
+        },
+        "ldap": {
+          "type": "object",
+          "additionalProperties": false,
+          "enterpriseOnly": true,
+          "properties": {
+            "disable-tls": {
+              "type": "boolean",
+              "default": false,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "login-threads": {
+              "type": "integer",
+              "default": 8,
+              "minimum": 1,
+              "maximum": 64,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "polling-period": {
+              "type": "integer",
+              "default": 300,
+              "minimum": 0,
+              "maximum": 86400,
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": true
+            },
+            "query-base-dn": {
+              "type": "string",
+              "default": "",
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "query-user-dn": {
+              "type": "string",
+              "default": "",
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "query-user-password-file": {
+              "type": "string",
+              "default": "",
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "role-query-base-dn": {
+              "type": "string",
+              "default": "",
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "role-query-patterns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true,
+              "default": []
+            },
+            "role-query-search-ou": {
+              "type": "boolean",
+              "default": false,
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "server": {
+              "type": "string",
+              "default": "",
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "tls-ca-file": {
+              "type": "string",
+              "default": "",
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "token-hash-method": {
+              "type": "string",
+              "default": "sha-256",
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "user-dn-pattern": {
+              "type": "string",
+              "default": "",
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            },
+            "user-query-pattern": {
+              "type": "string",
+              "default": "",
+              "description": "",
+              "dynamic": false,
+              "enterpriseOnly": true
+            }
+          }
+        },
+        "log": {
+          "type": "object",
+          "additionalProperties": false,
+          "enterpriseOnly": true,
+          "properties": {
+            "report-authentication": {
+              "type": "boolean",
+              "default": false,
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": true
+            },
+            "report-data-op": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": true,
+              "default": []
+            },
+            "report-data-op-role": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": true,
+              "default": []
+            },
+            "report-data-op-user": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": true,
+              "default": []
+            },
+            "report-sys-admin": {
+              "type": "boolean",
+              "default": false,
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": true
+            },
+            "report-user-admin": {
+              "type": "boolean",
+              "default": false,
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": true
+            },
+            "report-violation": {
+              "type": "boolean",
+              "default": false,
+              "description": "",
+              "dynamic": true,
+              "enterpriseOnly": true
+            }
+          }
+        }
+      }
+    },
+    "xdr": {
+      "type": "object",
+      "additionalProperties": false,
+      "enterpriseOnly": true,
+      "properties": {
+        "src-id": {
+          "type": "integer",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 255,
+          "description": "",
+          "dynamic": true,
+          "enterpriseOnly": true
+        },
+        "dcs": {
+          "type": "array",
+          "enterpriseOnly": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "default": " ",
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": true
+              },
+              "auth-mode": {
+                "type": "string",
+                "description": "",
+                "dynamic": true,
+                "enterpriseOnly": true,
+                "default": "none",
+                "enum": ["none", "internal", "external", "external-insecure", "pki"]
+              },
+              "auth-password-file": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": true,
+                "enterpriseOnly": true
+              },
+              "auth-user": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": true,
+                "enterpriseOnly": true
+              },
+              "connector": {
+                "type": "boolean",
+                "default": false,
+                "description": "",
+                "dynamic": true,
+                "enterpriseOnly": true
+              },
+              "max-recoveries-interleaved": {
+                "type": "integer",
+                "default": 0,
+                "minimum": 0,
+                "maximum": 4294967295,
+                "description": "",
+                "dynamic": true,
+                "enterpriseOnly": true
+              },
+              "node-address-ports": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "",
+                "dynamic": false,
+                "enterpriseOnly": true,
+                "default": []
+              },
+              "period-ms": {
+                "type": "integer",
+                "default": 100,
+                "minimum": 5,
+                "maximum": 1000,
+                "description": "",
+                "dynamic": true,
+                "enterpriseOnly": true
+              },
+              "recovery-threads": {
+                "type": "integer",
+                "default": 1,
+                "minimum": 1,
+                "maximum": 32,
+                "description": "",
+                "dynamic": true,
+                "enterpriseOnly": true
+              },
+              "tls-name": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": true,
+                "enterpriseOnly": true
+              },
+              "use-alternate-access-address": {
+                "type": "boolean",
+                "default": false,
+                "description": "",
+                "dynamic": true,
+                "enterpriseOnly": true
+              },
+              "namespaces": {
+                "type": "array",
+                "enterpriseOnly": true,
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "default": " ",
+                      "description": "",
+                      "dynamic": false,
+                      "enterpriseOnly": true
+                    },
+                    "bin-policy": {
+                      "type": "string",
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true,
+                      "default": "all",
+                      "enum": ["all", "no-bins", "only-changed", "changed-and-specified", "changed-or-specified"]
+                    },
+                    "compression-level": {
+                      "type": "integer",
+                      "default": 1,
+                      "minimum": 1,
+                      "maximum": 9,
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "compression-threshold": {
+                      "type": "integer",
+                      "default": 128,
+                      "minimum": 128,
+                      "maximum": 4294967295,
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "delay-ms": {
+                      "type": "integer",
+                      "default": 0,
+                      "minimum": 0,
+                      "maximum": 5000,
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "enable-compression": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "forward": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "hot-key-ms": {
+                      "type": "integer",
+                      "default": 100,
+                      "minimum": 0,
+                      "maximum": 5000,
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "ignore-bins": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true,
+                      "default": []
+                    },
+                    "ignore-expunges": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "ignore-sets": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true,
+                      "default": []
+                    },
+                    "max-throughput": {
+                      "type": "integer",
+                      "default": 100000,
+                      "minimum": 0,
+                      "maximum": 4294967295,
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "remote-namespace": {
+                      "type": "string",
+                      "default": "",
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "sc-replication-wait-ms": {
+                      "type": "integer",
+                      "default": 100,
+                      "minimum": 5,
+                      "maximum": 1000,
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "ship-bins": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true,
+                      "default": []
+                    },
+                    "ship-bin-luts": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "ship-nsup-deletes": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "ship-only-specified-sets": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "ship-sets": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true,
+                      "default": []
+                    },
+                    "ship-versions-interval": {
+                      "type": "integer",
+                      "default": 60,
+                      "minimum": 1,
+                      "maximum": 3600,
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "ship-versions-policy": {
+                      "type": "string",
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true,
+                      "default": "latest",
+                      "enum": ["latest", "all", "interval"]
+                    },
+                    "transaction-queue-limit": {
+                      "type": "integer",
+                      "default": 16384,
+                      "minimum": 1024,
+                      "maximum": 1048576,
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true
+                    },
+                    "write-policy": {
+                      "type": "string",
+                      "description": "",
+                      "dynamic": true,
+                      "enterpriseOnly": true,
+                      "default": "auto",
+                      "enum": ["auto", "update", "replace"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "enterpriseOnly": false
+}


### PR DESCRIPTION
Add a new JSON Schema (draft-06) file for Aerospike 8.1.2 configuration at json/aerospike/8.1.2.json.

Adds **two** schema fields for Aerospike **8.1.2** relative to **8.1.1**. No removals or other property changes.

### Service

| Property | Type | Default | Constraints | Dynamic | Enterprise |
|----------|------|---------|-------------|---------|------------|
| `cgroup-mem-tracking` | `boolean` | `false` | — | yes | no |

### Namespace

| Property | Type | Default | Min | Max | Dynamic | Enterprise |
|----------|------|---------|-----|-----|---------|------------|
| `tomb-raider-unmark-threads` | `integer` | `0` | `0` | `128` | yes | yes |

